### PR TITLE
fix for fsutils.mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,5 @@ This plugin is required for [`lite-contextmenu`](https://github.com/takase1121/l
 
 ### Note : 
 
-```
 fsutils.delete() depends on os.remove() for deleting files and directories. While this works for files everywhere, it doesnot delete directories on Windows.
-```
+

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ This plugin introduces a few commands related to the filesystem (rename / move, 
 It also exports a few wrapper filesystem functions so that other plugins may use it.
 
 This plugin is required for [`lite-contextmenu`](https://github.com/takase1121/lite-contextmenu) to work with TreeView.
+
+### Note : 
+
+```
+fsutils.delete() depends on os.remove() for deleting files and directories. While this works for files everywhere, it doesnot delete directories on Windows.
+```

--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,7 @@ function fsutils.iterdir(dir)
     if not path then return end
     
     for _, file in ipairs(system.list_dir(path) or {}) do
-      stack[#stack + 1] = path .. '/' .. file
+      stack[#stack + 1] = path .. PATHSEP .. file
     end
     
     return path, system.get_file_info(path)
@@ -76,16 +76,22 @@ end
 function fsutils.mkdir(path)
   local segments = fsutils.split(path)
   if system.mkdir then
+    local p = ""
     for i = 1, #segments do
-      local p = table.concat(segments, PATHSEP, 1, i)
-      local stat = system.get_file_info(p)
-      if stat and stat.type == "file" then
-        return nil, "path exists as a file", p
-      end
-      local ok, err = system.mkdir(p)
-      if not ok then
-        return nil, err, p
-      end
+      p = table.concat(segments, PATHSEP, 1, i)
+    end
+    
+    if p == "" then
+      return nil, "path empty", p
+    end
+    
+    local stat = system.get_file_info(p)
+    if stat and stat.type == "file" then
+      return nil, "path exists as a file", p
+    end
+    local ok, err = system.mkdir(p)
+    if not ok then
+      return nil, err, p
     end
   else
     -- just wing it lol


### PR DESCRIPTION
As reported in #1, fsutils.mkdir did not create directories.

This pull contains fixes for :
- fsutils.mkdir now first concats the complete path and then attempts creation of directories
- README.md is now updated to reflect that os.remove does not delete directories on windows
- fixed a minor PATHSEP issue